### PR TITLE
refactor(market-radar): 提取共享 hash 工具并优化并行扫描

### DIFF
--- a/plugins/market-radar/scripts/preprocess/index.ts
+++ b/plugins/market-radar/scripts/preprocess/index.ts
@@ -10,7 +10,6 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as crypto from 'crypto';
 import {
   PreprocessResult,
   PreprocessMeta,
@@ -22,17 +21,10 @@ import {
 import { convertToMarkdown, isSupportedFormat, isPandocAvailable, isPdfToTextAvailable } from './convert';
 import { cleanMarkdown } from './clean';
 import { calculateStats } from './cleaners/types';
+import { calculateHash } from '../utils/hash';
 
 // Current preprocessor version - increment when cleaning rules change
 const PREPROCESSOR_VERSION = '1.0.0';
-
-/**
- * Calculate MD5 hash of file content
- */
-function calculateHash(filePath: string): string {
-  const content = fs.readFileSync(filePath);
-  return crypto.createHash('md5').update(content).digest('hex');
-}
 
 /**
  * Get metadata file path for a source file

--- a/plugins/market-radar/scripts/thematic/scan-cards.ts
+++ b/plugins/market-radar/scripts/thematic/scan-cards.ts
@@ -9,20 +9,12 @@
  */
 
 import { glob } from 'glob';
-import { readFileSync, existsSync, writeFileSync, statSync } from 'fs';
-import { createHash } from 'crypto';
+import { existsSync, readFileSync, writeFileSync, statSync } from 'fs';
 import { resolve, relative } from 'path';
 import type { ThemeState, CardRecord, ScanResult } from './types';
+import { calculateHash } from '../utils/hash';
 
 const STATE_VERSION = '1.0';
-
-/**
- * 计算文件内容 MD5 哈希
- */
-function calculateHash(filePath: string): string {
-  const content = readFileSync(filePath, 'utf-8');
-  return createHash('md5').update(content).digest('hex');
-}
 
 /**
  * 获取文件修改时间
@@ -78,14 +70,10 @@ async function scanCards(sourceDir: string, statePath: string, incremental: bool
     'Capital-Investment'
   ];
 
-  // 扫描所有情报卡片
+  // 扫描所有情报卡片（并行扫描提高效率）
   const patterns = domains.map(d => `${absoluteSourceDir}/${d}/*.md`);
-  const cardFiles: string[] = [];
-
-  for (const pattern of patterns) {
-    const files = await glob(pattern);
-    cardFiles.push(...files);
-  }
+  const results = await Promise.all(patterns.map(p => glob(p)));
+  const cardFiles = results.flat();
 
   const newCards: string[] = [];
   const updatedCards: string[] = [];
@@ -93,7 +81,7 @@ async function scanCards(sourceDir: string, statePath: string, incremental: bool
 
   for (const cardFile of cardFiles) {
     const relativePath = relative(absoluteSourceDir, cardFile);
-    const currentHash = calculateHash(cardFile);
+    const currentHash = calculateHash(cardFile, 'utf-8');
     const currentMtime = getMtime(cardFile);
 
     const existingRecord = state.cards[relativePath];

--- a/plugins/market-radar/scripts/utils/hash.ts
+++ b/plugins/market-radar/scripts/utils/hash.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared hash utilities
+ */
+
+import { readFileSync } from 'fs';
+import { createHash } from 'crypto';
+
+/**
+ * Calculate MD5 hash of file content
+ *
+ * @param filePath - Path to the file
+ * @param encoding - Encoding to use ('buffer' for binary, 'utf-8' for text)
+ * @returns MD5 hash as hex string
+ */
+export function calculateHash(
+  filePath: string,
+  encoding: 'buffer' | 'utf-8' = 'buffer'
+): string {
+  const content = encoding === 'utf-8'
+    ? readFileSync(filePath, 'utf-8')
+    : readFileSync(filePath);
+  return createHash('md5').update(content).digest('hex');
+}


### PR DESCRIPTION
## Summary

- 新增 `utils/hash.ts` 共享模块，统一 `calculateHash` 实现
- `preprocess/index.ts` 使用共享模块（buffer 模式，支持二进制文件）
- `thematic/scan-cards.ts` 使用共享模块（utf-8 模式，仅文本文件）
- 优化 `scan-cards.ts` 中 glob 扫描为并行执行，提升效率

## Changes

| 文件 | 变更 |
|------|------|
| `utils/hash.ts` | 新增共享 hash 工具模块 |
| `preprocess/index.ts` | 移除重复的 `calculateHash` 函数 |
| `thematic/scan-cards.ts` | 移除重复代码 + 并行 glob 扫描 |

## Test plan

- [x] TypeScript 类型检查通过 (`npx tsc --noEmit`)
- [x] 提交符合 Conventional Commits 规范

🤖 Generated with [Claude Code](https://claude.com/claude-code)