### PR TITLE
fix(market-radar): 修复 cleaner scope 逻辑和错误码处理

### DIFF
--- a/plugins/market-radar/scripts/preprocess/cleaners/index.ts
+++ b/plugins/market-radar/scripts/preprocess/cleaners/index.ts
@@ -27,8 +27,10 @@ export class CleanerOrchestrator {
         return true;
 
       case 'basic':
-        // Basic rules: apply to unknown + all specific sources
-        return true;
+        // Basic rules: apply to unknown + web sources only
+        // These rules target web-specific noise (ICP, share buttons, copyright)
+        // that should not be applied to PDF reports, WeChat articles, etc.
+        return source === 'unknown' || source === 'web';
 
       case 'specific':
         // Specific rules: only apply to matching sources

--- a/plugins/market-radar/scripts/preprocess/cleaners/types.ts
+++ b/plugins/market-radar/scripts/preprocess/cleaners/types.ts
@@ -130,11 +130,11 @@ export function detectSource(
   content: string,
   filePath: string
 ): DetectionResult {
-  const scores: Map<DocumentSource, { score: number; signals: string[] }> = new Map();
+  const scores: Map<DocumentSource, { score: number; signals: Set<string> }> = new Map();
 
-  // Initialize
+  // Initialize with Set to avoid duplicate signals
   for (const signal of SOURCE_SIGNALS) {
-    scores.set(signal.source, { score: 0, signals: [] });
+    scores.set(signal.source, { score: 0, signals: new Set() });
   }
 
   // Check file extension
@@ -142,17 +142,22 @@ export function detectSource(
   if (ext === '.pdf') {
     const current = scores.get('pdf-report')!;
     current.score += 0.3;
-    current.signals.push('file-extension:pdf');
+    current.signals.add('file-extension:pdf');
   }
 
-  // Check content signals
+  // Check content signals - add signal name only once per signal group
   for (const signal of SOURCE_SIGNALS) {
+    let matched = false;
     for (const pattern of signal.contentSignals) {
       if (pattern.test(content)) {
-        const current = scores.get(signal.source)!;
-        current.score += signal.weight;
-        current.signals.push(signal.signalName);
+        matched = true;
+        break; // No need to check other patterns in same group
       }
+    }
+    if (matched) {
+      const current = scores.get(signal.source)!;
+      current.score += signal.weight;
+      current.signals.add(signal.signalName);
     }
   }
 
@@ -165,7 +170,7 @@ export function detectSource(
     if (data.score > maxScore) {
       maxScore = data.score;
       maxSource = source;
-      matchedSignals = data.signals;
+      matchedSignals = Array.from(data.signals);
     }
   });
 

--- a/plugins/market-radar/scripts/preprocess/index.ts
+++ b/plugins/market-radar/scripts/preprocess/index.ts
@@ -80,14 +80,43 @@ async function processFile(
   currentVersion: string,
   sourceDir: string
 ): Promise<PreprocessResult> {
+  let rawContent: string;
+
+  // Phase 1: Conversion
   try {
-    // Read and convert
-    const rawContent = await convertToMarkdown(sourcePath);
+    rawContent = await convertToMarkdown(sourcePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    let code: PreprocessErrorCode = 'CONVERSION_FAILED';
 
-    // Clean with source-aware rules
-    const cleanResult = await cleanMarkdown(rawContent, sourcePath);
-    const cleanedContent = cleanResult.content;
+    if (message.includes('not found') || message.includes('not installed')) {
+      code = 'DEPENDENCY_MISSING';
+    } else if (message.includes('Cannot read') || message.includes('ENOENT')) {
+      code = 'READ_FAILED';
+    }
 
+    return {
+      success: false,
+      error: { code, message },
+    };
+  }
+
+  // Phase 2: Cleaning
+  let cleanResult: { content: string; source: string; appliedRules: string[]; stats: { originalSize: number; cleanedSize: number; compressionRate: number } };
+  try {
+    cleanResult = await cleanMarkdown(rawContent, sourcePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: { code: 'CLEAN_FAILED', message },
+    };
+  }
+
+  const cleanedContent = cleanResult.content;
+
+  // Phase 3: Write output
+  try {
     // Ensure output directory exists
     const outputDir = path.dirname(convertedPath);
     if (!fs.existsSync(outputDir)) {
@@ -109,27 +138,19 @@ async function processFile(
       stats: cleanResult.stats,
     };
     fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
-
-    return {
-      success: true,
-      markdown: cleanedContent,
-      stats: cleanResult.stats,
-    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    let code: PreprocessErrorCode = 'CONVERSION_FAILED';
-
-    if (message.includes('not found') || message.includes('not installed')) {
-      code = 'DEPENDENCY_MISSING';
-    } else if (message.includes('Cannot read') || message.includes('ENOENT')) {
-      code = 'READ_FAILED';
-    }
-
     return {
       success: false,
-      error: { code, message },
+      error: { code: 'READ_FAILED', message: `Failed to write output: ${message}` },
     };
   }
+
+  return {
+    success: true,
+    markdown: cleanedContent,
+    stats: cleanResult.stats,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **H2**: 修复 `basic` scope 行为与 `common` 相同的问题
  - `basic` cleaner 现在仅对 `unknown` 和 `web` 来源应用
  - 避免网页噪声规则（ICP、分享按钮、版权声明）误删 PDF 报告等特定来源内容
  
- **H3**: 修复 `CLEAN_FAILED` 错误码不可达的问题
  - 重构 `processFile` 函数，区分转换阶段和清洗阶段的错误
  - 清洗阶段错误正确返回 `CLEAN_FAILED` 错误码，提高错误诊断准确性
  
- **H1**: 优化信号权重累加逻辑
  - 使用 `Set` 避免 `matchedSignals` 数组重复
  - 每个 signal 组只计算一次权重和添加一次信号名

## Test plan

- [x] TypeScript 类型检查通过 (`npx tsc --noEmit`)
- [ ] 实际运行预处理脚本验证功能正常

## Changes

| 文件 | 变更 |
|------|------|
| `cleaners/index.ts` | 修复 `basic` scope 判断逻辑 |
| `cleaners/types.ts` | 优化 `detectSource` 函数，使用 Set 去重 |
| `preprocess/index.ts` | 重构 `processFile`，分阶段错误处理 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)