### PR TITLE
docs: 在项目概述中明确仓库位置和组织信息

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@
 
 **Cyber Nexus** 是一个 Claude Code 插件集合，致力于将 AI 能力融入网络安全战略规划和产品管理的核心流程。
 
+**仓库**: `https://github.com/cyberstrat-forge/cyber-nexus.git` (组织: `cyberstrat-forge`，非个人仓库)
+
 当前状态：早期开发阶段，插件 `market-radar` 已发布两个核心命令。
 
 ## 技术栈


### PR DESCRIPTION

## Summary
- 在 CLAUDE.md 的项目概述中添加仓库地址：
- 明确标注组织为 （非个人仓库 ）
- 避免 AI 在使用 GitHub MCP 时误判仓库位置

## Test plan
- [x] 确认 CLAUDE.md 修改后清晰标明仓库位置
- [x] 验证提交信息符合 Conventional Commits 规范
- [x] 确认修改不影响其他文档内容
