### PR TITLE
fix(market-radar): correct Agent tools field YAML format

### DIFF
--- a/plugins/market-radar/.claude-plugin/plugin.json
+++ b/plugins/market-radar/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "market-radar",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Strategic market intelligence for cybersecurity strategic planning",
   "author": {
     "name": "luoweirong",

--- a/plugins/market-radar/CHANGELOG.md
+++ b/plugins/market-radar/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 本文件记录 market-radar 插件的所有重要变更。格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [1.4.1] - 2026-04-01
+
+### 修复
+
+- **Agent tools 字段格式修复**
+  - 修正 YAML frontmatter 中 `tools` 字段格式：从逗号分隔字符串改为 YAML 数组格式
+  - 格式变更：`tools: Read, Write` → `tools: ["Read", "Write"]`
+  - 修复 Agent 无法获取 Write 工具权限导致情报卡片写入失败的问题
+  - 受影响文件：`intelligence-analyzer.md`, `intelligence-briefing-writer.md`, `intelligence-cluster.md`, `panorama-synthesizer.md`, `theme-analyzer.md`
+
 ## [1.4.0] - 2026-04-01
 
 ### 新增
@@ -440,6 +450,7 @@ intel-distill → 处理 inbox/ → 生成情报卡片 → intelligence/
 - 支持 Markdown、PDF、Word 文档处理
 - 实现增量处理机制
 
+[1.4.1]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.3.3...v1.4.0
 [1.3.3]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.3.1...v1.3.2

--- a/plugins/market-radar/agents/intelligence-analyzer.md
+++ b/plugins/market-radar/agents/intelligence-analyzer.md
@@ -14,7 +14,7 @@ description: |
 
 model: inherit
 color: cyan
-tools: Read, Grep, Glob, Write, Bash
+tools: ["Read", "Grep", "Glob", "Write", "Bash"]
 skills:
   - cybersecurity-domain-knowledge
   - intelligence-analysis-methodology

--- a/plugins/market-radar/agents/intelligence-briefing-writer.md
+++ b/plugins/market-radar/agents/intelligence-briefing-writer.md
@@ -32,7 +32,7 @@ description: |
 
 model: inherit
 color: blue
-tools: Read, Write
+tools: ["Read", "Write"]
 skills:
   - cybersecurity-domain-knowledge
 ---

--- a/plugins/market-radar/agents/intelligence-cluster.md
+++ b/plugins/market-radar/agents/intelligence-cluster.md
@@ -23,7 +23,7 @@ description: |
 
 model: inherit
 color: cyan
-tools: Read, Grep, Glob, Write, Bash
+tools: ["Read", "Grep", "Glob", "Write", "Bash"]
 skills:
   - clustering-methodology
   - cybersecurity-domain-knowledge

--- a/plugins/market-radar/agents/panorama-synthesizer.md
+++ b/plugins/market-radar/agents/panorama-synthesizer.md
@@ -23,7 +23,7 @@ description: |
 
 model: inherit
 color: magenta
-tools: Read, Grep, Glob, Write
+tools: ["Read", "Grep", "Glob", "Write"]
 skills:
   - thematic-templates
 ---

--- a/plugins/market-radar/agents/theme-analyzer.md
+++ b/plugins/market-radar/agents/theme-analyzer.md
@@ -23,7 +23,7 @@ description: |
 
 model: inherit
 color: green
-tools: Read, Grep, Glob, Write, Bash
+tools: ["Read", "Grep", "Glob", "Write", "Bash"]
 skills:
   - thematic-methodology
   - cybersecurity-domain-knowledge


### PR DESCRIPTION
## Summary

- 修复 Agent frontmatter 中 `tools` 字段的 YAML 格式问题
- 从逗号分隔字符串格式改为正确的 YAML 数组格式
- 解决 Agent 无法获取 Write 工具权限导致情报卡片写入失败的问题

## Changes

| 文件 | 变更 |
|------|------|
| `intelligence-analyzer.md` | `tools: ["Read", "Grep", "Glob", "Write", "Bash"]` |
| `intelligence-briefing-writer.md` | `tools: ["Read", "Write"]` |
| `intelligence-cluster.md` | `tools: ["Read", "Grep", "Glob", "Write", "Bash"]` |
| `panorama-synthesizer.md` | `tools: ["Read", "Grep", "Glob", "Write"]` |
| `theme-analyzer.md` | `tools: ["Read", "Grep", "Glob", "Write", "Bash"]` |
| `plugin.json` | 版本号 1.4.0 → 1.4.1 |
| `CHANGELOG.md` | 添加 1.4.1 版本记录 |

## Root Cause

YAML 解析器将逗号分隔的字符串 `tools: Read, Write` 解析为单个字符串值，而不是数组。导致 Claude Code 无法正确识别 Agent 需要的工具权限，拒绝了 Write 操作。

## Test Plan

- [ ] 运行 `/intel-distill` 命令验证 Agent 可以正常写入情报卡片
- [ ] 运行 `/thematic-analysis` 命令验证相关 Agent 功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)