### PR TITLE
docs(market-radar): warn against run_in_background for Agent calls

### DIFF
--- a/plugins/market-radar/commands/intel-distill.md
+++ b/plugins/market-radar/commands/intel-distill.md
@@ -510,6 +510,14 @@ if (needs_processing + pending_review >= 50) {
 
 **并行执行时**：在单个消息中发起多个 Agent 调用，由 Claude Code 自动管理并发
 
+> ⚠️ **禁止使用 `run_in_background=true`**
+>
+> 后台 Agent 运行在独立上下文中，**无法继承父会话的工具权限**（包括 Write）。
+> 这会导致情报卡片写入失败，返回 `Permission to use Write has been denied` 错误。
+>
+> **正确做法**：在单消息中发起多个 Agent 调用（不设置 `run_in_background`），
+> Claude Code 会自动并行执行，同时保持权限继承。
+
 **Agent 工具权限**：
 - Read: 读取转换后的 Markdown 文件
 - Grep: 搜索文档中的关键信息


### PR DESCRIPTION
## Summary

- 在 `intel-distill.md` 中添加警告，禁止使用 `run_in_background=true`
- 解释后台 Agent 无法继承工具权限的原因
- 说明正确的前台并行执行方式

## Background

经测试验证，使用 `run_in_background=true` 启动的后台 Agent 运行在独立上下文中，无法继承父会话的工具权限（包括 Write），导致情报卡片写入失败。

## Changes

```diff
+> ⚠️ **禁止使用 `run_in_background=true`**
+>
+> 后台 Agent 运行在独立上下文中，**无法继承父会话的工具权限**（包括 Write）。
+> 这会导致情报卡片写入失败，返回 `Permission to use Write has been denied` 错误。
+>
+> **正确做法**：在单消息中发起多个 Agent 调用（不设置 `run_in_background`），
+> Claude Code 会自动并行执行，同时保持权限继承。
```

## Note

此更改仅为文档更新，无需发布新版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)