### PR TITLE
chore: sync marketplace.json version to 1.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "market-radar",
       "source": "./plugins/market-radar",
       "description": "从文档提取战略情报，支持七大情报领域",
-      "version": "1.2.7"
+      "version": "1.4.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

同步 `marketplace.json` 版本号从 `1.2.7` → `1.4.1`

## Background

| 文件 | 版本 |
|------|------|
| `plugin.json` | 1.4.1 ✅ |
| `marketplace.json` | 1.2.7 ❌ |

两个版本号不同步，导致用户在插件市场看到的是旧版本号。

## Changes

```diff
- "version": "1.2.7"
+ "version": "1.4.1"
```

## Note

此更改仅为版本号同步，无需发布新版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)