### PR TITLE
chore: release market-radar v1.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "market-radar",
       "source": "./plugins/market-radar",
       "description": "从文档提取战略情报，支持七大情报领域",
-      "version": "1.6.1"
+      "version": "1.7.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@
 
 ---
 
+## [1.0.21] - 2026-04-05
+
+### 插件更新
+
+#### market-radar v1.7.0
+
+**新增**
+- 年月子目录结构：情报卡片输出改为 `{domain}/{YYYY}/{MM}/{filename}.md` 格式
+- Obsidian Bases 索引：自动为各领域目录生成 `_index.base` 文件
+- obsidian-cli skill：支持通过 Obsidian CLI 进行文件操作、属性读写、Bases 查询
+- 历史文件迁移脚本：`migrate-to-yearly-folders.ts` 支持将扁平结构迁移到年月子目录
+
+**变更**
+- intelligence-analyzer Agent：更新输出路径逻辑，支持年月子目录结构
+- intelligence-output-templates Skill：更新输出结构文档
+
+**修复**
+- scan-cards.ts：使用递归 glob pattern 支持年月子目录扫描
+- migrate-to-yearly-folders.ts：多层错误处理增强健壮性
+
+---
+
 ## [1.0.20] - 2026-04-03
 
 ### 插件更新


### PR DESCRIPTION
## Summary

- 更新 `marketplace.json` 中 market-radar 版本号至 1.7.0
- 更新仓库 CHANGELOG.md 添加 v1.7.0 发布说明

## 版本发布说明

market-radar v1.7.0 包含以下更新：

**新增**
- 年月子目录结构：`{domain}/{YYYY}/{MM}/{filename}.md`
- Obsidian Bases 索引自动生成
- obsidian-cli skill
- 历史文件迁移脚本

**修复**
- scan-cards.ts 递归扫描支持
- 多层错误处理增强

## Test plan

- [ ] 验证 marketplace.json 版本号正确
- [ ] 验证 CHANGELOG.md 格式正确
- [ ] 合并后用户可通过插件市场升级

🤖 Generated with [Claude Code](https://claude.com/claude-code)