### PR TITLE
chore: release market-radar v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ---
 
+## [1.0.23] - 2026-04-05
+
+### 插件更新
+
+#### market-radar v1.7.2
+
+**变更**
+- intel-distill 默认参数优化：`--source` 默认 `./inbox`，`--output` 默认 `./intelligence`
+- `archive/`、`converted/`、`.intel/` 始终在项目根目录下
+
+---
+
 ## [1.0.22] - 2026-04-05
 
 ### 插件更新
@@ -384,6 +396,9 @@
 
 ---
 
+[1.0.23]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.22...v1.0.23
+[1.0.22]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.21...v1.0.22
+[1.0.21]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.20...v1.0.21
 [1.0.20]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.19...v1.0.20
 [1.0.19]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.18...v1.0.19
 [1.0.18]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.17...v1.0.18

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cyber Nexus
 
-[![Version](https://img.shields.io/badge/version-1.0.17-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.17)
+[![Version](https://img.shields.io/badge/version-1.0.23-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.23)
 [![CI](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml/badge.svg)](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
@@ -16,7 +16,7 @@ Cyber Nexus 是一个 Claude Code 插件集合，致力于将 AI 能力融入网
 
 | 插件 | 版本 | 状态 | 描述 |
 |------|------|------|------|
-| [market-radar](./plugins/market-radar) | 1.3.3 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
+| [market-radar](./plugins/market-radar) | 1.7.2 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
 | competitive-analysis | - | 📋 规划中 | 竞争对手分析与对比 |
 | product-management | - | 📋 规划中 | 产品管理与决策支持 |
 

--- a/plugins/market-radar/.claude-plugin/plugin.json
+++ b/plugins/market-radar/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "market-radar",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Strategic market intelligence for cybersecurity strategic planning",
   "author": {
     "name": "luoweirong",

--- a/plugins/market-radar/CHANGELOG.md
+++ b/plugins/market-radar/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 本文件记录 market-radar 插件的所有重要变更。格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [1.7.2] - 2026-04-05
+
+### 变更
+
+- **intel-distill 默认参数优化**
+  - `--source` 默认值改为 `./inbox`，避免扫描根目录其他文件
+  - `--output` 默认值改为 `./intelligence`
+  - `archive/`、`converted/`、`.intel/` 始终在项目根目录下
+
 ## [1.7.1] - 2026-04-05
 
 ### 变更
@@ -538,6 +547,9 @@ intel-distill → 处理 inbox/ → 生成情报卡片 → intelligence/
 - 支持 Markdown、PDF、Word 文档处理
 - 实现增量处理机制
 
+[1.7.2]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.1...v1.7.2
+[1.7.1]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.4.1...v1.5.0


### PR DESCRIPTION
## Summary

发布 market-radar v1.7.2，更新版本号和文档。

## Changes

| 文件 | 变更 |
|------|------|
| plugin.json | 1.7.1 → 1.7.2 |
| 插件 CHANGELOG.md | 新增 1.7.2 条目 |
| 仓库 CHANGELOG.md | 新增 1.0.23 条目 |
| README.md | 版本徽章和插件列表更新 |

## Test plan

- [x] 版本号正确更新
- [x] CHANGELOG 格式符合规范
- [ ] 合并后推送 v1.0.23 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)