### PR TITLE
chore: release market-radar v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ---
 
+## [1.0.24] - 2026-04-05
+
+### 插件更新
+
+#### market-radar v1.7.3
+
+**变更**
+- intel-pull 添加 `--root` 参数，状态文件统一在项目根目录
+- 与 intel-distill 命令保持一致的路径逻辑
+
+---
+
 ## [1.0.23] - 2026-04-05
 
 ### 插件更新
@@ -396,6 +408,7 @@
 
 ---
 
+[1.0.24]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.23...v1.0.24
 [1.0.23]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.22...v1.0.23
 [1.0.22]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.21...v1.0.22
 [1.0.21]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.20...v1.0.21

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cyber Nexus
 
-[![Version](https://img.shields.io/badge/version-1.0.23-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.23)
+[![Version](https://img.shields.io/badge/version-1.0.24-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.24)
 [![CI](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml/badge.svg)](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
@@ -16,7 +16,7 @@ Cyber Nexus 是一个 Claude Code 插件集合，致力于将 AI 能力融入网
 
 | 插件 | 版本 | 状态 | 描述 |
 |------|------|------|------|
-| [market-radar](./plugins/market-radar) | 1.7.2 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
+| [market-radar](./plugins/market-radar) | 1.7.3 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
 | competitive-analysis | - | 📋 规划中 | 竞争对手分析与对比 |
 | product-management | - | 📋 规划中 | 产品管理与决策支持 |
 

--- a/plugins/market-radar/.claude-plugin/plugin.json
+++ b/plugins/market-radar/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "market-radar",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Strategic market intelligence for cybersecurity strategic planning",
   "author": {
     "name": "luoweirong",

--- a/plugins/market-radar/CHANGELOG.md
+++ b/plugins/market-radar/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 本文件记录 market-radar 插件的所有重要变更。格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [1.7.3] - 2026-04-05
+
+### 变更
+
+- **intel-pull 命令增强**
+  - 添加 `--root` 参数，状态文件始终在项目根目录下
+  - 与 `intel-distill` 命令保持一致的路径逻辑
+  - 输出目录默认 `./inbox`（相对于根目录）
+
 ## [1.7.2] - 2026-04-05
 
 ### 变更
@@ -547,6 +556,7 @@ intel-distill → 处理 inbox/ → 生成情报卡片 → intelligence/
 - 支持 Markdown、PDF、Word 文档处理
 - 实现增量处理机制
 
+[1.7.3]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.6.1...v1.7.0


### PR DESCRIPTION
## Summary

发布 market-radar v1.7.3，包含 intel-pull 命令的 `--root` 参数增强。

## Changes

| 文件 | 变更 |
|------|------|
| plugin.json | 1.7.2 → 1.7.3 |
| 插件 CHANGELOG.md | 新增 1.7.3 条目 |
| 仓库 CHANGELOG.md | 新增 1.0.24 条目 |
| README.md | 版本徽章和插件列表更新 |

## Test plan

- [x] 版本号正确更新
- [x] CHANGELOG 格式符合规范
- [ ] 合并后推送 v1.0.24 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)