### PR TITLE
fix(market-radar): resolve TypeScript type definition errors

### DIFF
--- a/plugins/market-radar/scripts/preprocess/index.ts
+++ b/plugins/market-radar/scripts/preprocess/index.ts
@@ -100,8 +100,8 @@ function collectKnownFiles(sourceDir: string): Set<string> {
   let years: string[];
   try {
     years = fs.readdirSync(convertedBase, { withFileTypes: true })
-      .filter(e => e.isDirectory() && /^\d{4}$/.test(e.name))
-      .map(e => e.name);
+      .filter((e: fs.Dirent) => e.isDirectory() && /^\d{4}$/.test(e.name))
+      .map((e: fs.Dirent) => e.name);
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     console.warn(`Warning: Cannot read converted directory ${convertedBase}: ${errMsg}`);
@@ -112,8 +112,8 @@ function collectKnownFiles(sourceDir: string): Set<string> {
     let months: string[];
     try {
       months = fs.readdirSync(path.join(convertedBase, year), { withFileTypes: true })
-        .filter(e => e.isDirectory() && /^\d{2}$/.test(e.name))
-        .map(e => e.name);
+        .filter((e: fs.Dirent) => e.isDirectory() && /^\d{2}$/.test(e.name))
+        .map((e: fs.Dirent) => e.name);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       console.warn(`Warning: Cannot read year directory ${year}: ${errMsg}`);
@@ -125,8 +125,8 @@ function collectKnownFiles(sourceDir: string): Set<string> {
       let files: string[];
       try {
         files = fs.readdirSync(monthDir, { withFileTypes: true })
-          .filter(e => e.isFile() && e.name.endsWith('.md'))
-          .map(e => e.name);
+          .filter((e: fs.Dirent) => e.isFile() && e.name.endsWith('.md'))
+          .map((e: fs.Dirent) => e.name);
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);
         console.warn(`Warning: Cannot read month directory ${monthDir}: ${errMsg}`);
@@ -309,8 +309,8 @@ function collectKnownHashes(sourceDir: string): Map<string, string> {
   let years: string[];
   try {
     years = fs.readdirSync(convertedBase, { withFileTypes: true })
-      .filter(e => e.isDirectory() && /^\d{4}$/.test(e.name))
-      .map(e => e.name);
+      .filter((e: fs.Dirent) => e.isDirectory() && /^\d{4}$/.test(e.name))
+      .map((e: fs.Dirent) => e.name);
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     console.warn(`Warning: Cannot read converted directory ${convertedBase}: ${errMsg}`);
@@ -321,8 +321,8 @@ function collectKnownHashes(sourceDir: string): Map<string, string> {
     let months: string[];
     try {
       months = fs.readdirSync(path.join(convertedBase, year), { withFileTypes: true })
-        .filter(e => e.isDirectory() && /^\d{2}$/.test(e.name))
-        .map(e => e.name);
+        .filter((e: fs.Dirent) => e.isDirectory() && /^\d{2}$/.test(e.name))
+        .map((e: fs.Dirent) => e.name);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       console.warn(`Warning: Cannot read year directory ${year}: ${errMsg}`);
@@ -334,8 +334,8 @@ function collectKnownHashes(sourceDir: string): Map<string, string> {
       let files: string[];
       try {
         files = fs.readdirSync(monthDir, { withFileTypes: true })
-          .filter(e => e.isFile() && e.name.endsWith('.md'))
-          .map(e => e.name);
+          .filter((e: fs.Dirent) => e.isFile() && e.name.endsWith('.md'))
+          .map((e: fs.Dirent) => e.name);
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);
         console.warn(`Warning: Cannot read month directory ${monthDir}: ${errMsg}`);

--- a/plugins/market-radar/scripts/pulse/index.ts
+++ b/plugins/market-radar/scripts/pulse/index.ts
@@ -20,7 +20,6 @@ import { fileURLToPath } from 'url';
 import {
   PullOptions,
   PullResult,
-  PullSourceResult,
   PullSourceResultSuccess,
   PullSourceResultFailure,
   PulseSource,
@@ -97,7 +96,7 @@ function createReadlineInterface(): readline.Interface {
  */
 function prompt(rl: readline.Interface, question: string): Promise<string> {
   return new Promise((resolve) => {
-    rl.question(question, (answer) => {
+    rl.question(question, (answer: string) => {
       resolve(answer.trim());
     });
   });

--- a/plugins/market-radar/scripts/tsconfig.json
+++ b/plugins/market-radar/scripts/tsconfig.json
@@ -9,7 +9,8 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["node"]
   },
   "include": ["./**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

修复 TypeScript 类型定义错误，消除 IDE 和 CLI 中的类型告警。

## Changes

| 文件 | 变更 |
|------|------|
| tsconfig.json | 添加 `types: ["node"]` 配置 |
| preprocess/index.ts | 为 `fs.readdirSync` 回调添加 `fs.Dirent` 类型注解 |
| pulse/index.ts | 为 `readline.question` 回调添加 `string` 类型注解；移除未使用的 `PullSourceResult` 导入 |

## Root Cause

TypeScript 在严格模式下无法自动推断 `fs.readdirSync` 和 `readline.question` 回调参数的类型，需要显式类型注解。

## Test plan

- [x] `pnpm exec tsc --noEmit` 无错误输出
- [x] 脚本正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)