### PR TITLE
chore: release market-radar v1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 ---
 
+## [1.0.25] - 2026-04-05
+
+### 插件更新
+
+#### market-radar v1.7.4
+
+**修复**
+- TypeScript 类型定义：添加 `types: ["node"]` 到 tsconfig
+- 配置文件位置：`pulse-sources.json` 移至项目根目录，避免升级覆盖
+- 错误处理：rootDir 验证、mkdirSync 错误处理、迁移引导
+
+---
+
 ## [1.0.24] - 2026-04-05
 
 ### 插件更新
@@ -408,6 +421,7 @@
 
 ---
 
+[1.0.25]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.24...v1.0.25
 [1.0.24]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.23...v1.0.24
 [1.0.23]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.22...v1.0.23
 [1.0.22]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.21...v1.0.22

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cyber Nexus
 
-[![Version](https://img.shields.io/badge/version-1.0.24-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.24)
+[![Version](https://img.shields.io/badge/version-1.0.25-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.25)
 [![CI](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml/badge.svg)](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
@@ -16,7 +16,7 @@ Cyber Nexus 是一个 Claude Code 插件集合，致力于将 AI 能力融入网
 
 | 插件 | 版本 | 状态 | 描述 |
 |------|------|------|------|
-| [market-radar](./plugins/market-radar) | 1.7.3 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
+| [market-radar](./plugins/market-radar) | 1.7.4 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
 | competitive-analysis | - | 📋 规划中 | 竞争对手分析与对比 |
 | product-management | - | 📋 规划中 | 产品管理与决策支持 |
 

--- a/plugins/market-radar/.claude-plugin/plugin.json
+++ b/plugins/market-radar/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "market-radar",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Strategic market intelligence for cybersecurity strategic planning",
   "author": {
     "name": "luoweirong",

--- a/plugins/market-radar/CHANGELOG.md
+++ b/plugins/market-radar/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 本文件记录 market-radar 插件的所有重要变更。格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [1.7.4] - 2026-04-05
+
+### 修复
+
+- **TypeScript 类型定义**：修复 tsconfig 缺少 `types: ["node"]` 导致的类型错误
+- **配置文件位置**：`pulse-sources.json` 移至项目根目录 `.intel/`，避免插件升级时被覆盖
+- **错误处理增强**：
+  - 添加 `rootDir` 参数验证
+  - 包裹 `mkdirSync` 错误处理
+  - `generateReport` 区分错误类型
+  - 检测旧配置位置并提供迁移引导
+
 ## [1.7.3] - 2026-04-05
 
 ### 变更
@@ -556,6 +568,7 @@ intel-distill → 处理 inbox/ → 生成情报卡片 → intelligence/
 - 支持 Markdown、PDF、Word 文档处理
 - 实现增量处理机制
 
+[1.7.4]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.3...v1.7.4
 [1.7.3]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.0...v1.7.1


### PR DESCRIPTION
## Summary

发布 market-radar v1.7.4，包含 TypeScript 类型修复和配置文件位置迁移。

## Changes

| 文件 | 变更 |
|------|------|
| plugin.json | 1.7.3 → 1.7.4 |
| 插件 CHANGELOG.md | 新增 1.7.4 条目 |
| 仓库 CHANGELOG.md | 新增 1.0.25 条目 |
| README.md | 版本徽章和插件列表更新 |

## v1.7.4 Highlights

**修复**
- TypeScript 类型定义：添加 `types: ["node"]` 到 tsconfig
- 配置文件位置：`pulse-sources.json` 移至项目根目录 `.intel/`
- 错误处理：rootDir 验证、mkdirSync 错误处理、迁移引导

## Test plan

- [x] 版本号正确更新
- [x] CHANGELOG 格式符合规范
- [ ] 合并后推送 v1.0.25 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)