### PR TITLE
chore: release market-radar v1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ---
 
+## [1.0.26] - 2026-04-05
+
+### 插件更新
+
+#### market-radar v1.7.5
+
+**修复**
+- intel-pull 命令：所有脚本调用添加 `--root` 参数，修复路径错误
+
+---
+
 ## [1.0.25] - 2026-04-05
 
 ### 插件更新
@@ -421,6 +432,7 @@
 
 ---
 
+[1.0.26]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.25...v1.0.26
 [1.0.25]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.24...v1.0.25
 [1.0.24]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.23...v1.0.24
 [1.0.23]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.0.22...v1.0.23

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cyber Nexus
 
-[![Version](https://img.shields.io/badge/version-1.0.25-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.25)
+[![Version](https://img.shields.io/badge/version-1.0.26-blue.svg)](https://github.com/cyberstrat-forge/cyber-nexus/releases/tag/v1.0.26)
 [![CI](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml/badge.svg)](https://github.com/cyberstrat-forge/cyber-nexus/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
@@ -16,7 +16,7 @@ Cyber Nexus 是一个 Claude Code 插件集合，致力于将 AI 能力融入网
 
 | 插件 | 版本 | 状态 | 描述 |
 |------|------|------|------|
-| [market-radar](./plugins/market-radar) | 1.7.4 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
+| [market-radar](./plugins/market-radar) | 1.7.5 | ✅ 可用 | 从文档中提取战略情报，生成情报卡片和主题分析报告 |
 | competitive-analysis | - | 📋 规划中 | 竞争对手分析与对比 |
 | product-management | - | 📋 规划中 | 产品管理与决策支持 |
 

--- a/plugins/market-radar/.claude-plugin/plugin.json
+++ b/plugins/market-radar/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "market-radar",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Strategic market intelligence for cybersecurity strategic planning",
   "author": {
     "name": "luoweirong",

--- a/plugins/market-radar/CHANGELOG.md
+++ b/plugins/market-radar/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本文件记录 market-radar 插件的所有重要变更。格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [1.7.5] - 2026-04-05
+
+### 修复
+
+- **intel-pull 命令**：所有脚本调用添加 `--root` 参数，修复在 scripts/ 目录执行时路径错误的问题
+
 ## [1.7.4] - 2026-04-05
 
 ### 修复
@@ -568,6 +574,7 @@ intel-distill → 处理 inbox/ → 生成情报卡片 → intelligence/
 - 支持 Markdown、PDF、Word 文档处理
 - 实现增量处理机制
 
+[1.7.5]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.4...v1.7.5
 [1.7.4]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.3...v1.7.4
 [1.7.3]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/cyberstrat-forge/cyber-nexus/compare/v1.7.1...v1.7.2


### PR DESCRIPTION
## Summary

发布 market-radar v1.7.5，修复 intel-pull 命令路径问题。

## Changes

| 文件 | 变更 |
|------|------|
| plugin.json | 1.7.4 → 1.7.5 |
| 插件 CHANGELOG.md | 新增 1.7.5 条目 |
| 仓库 CHANGELOG.md | 新增 1.0.26 条目 |
| README.md | 版本徽章和插件列表更新 |

## v1.7.5 Highlights

**修复**
- intel-pull 命令：所有脚本调用添加 `--root` 参数，修复在 scripts/ 目录执行时路径错误

## Test plan

- [x] 版本号正确更新
- [x] CHANGELOG 格式符合规范
- [ ] 合并后推送 v1.0.26 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)