### PR TITLE
fix(market-radar): use slash separator for Obsidian nested tags

### DIFF
--- a/plugins/market-radar/agents/intelligence-analyzer.md
+++ b/plugins/market-radar/agents/intelligence-analyzer.md
@@ -181,18 +181,20 @@ source_score: 85
 
 ### 步骤 4.1：地域范围与标签生成
 
-**tags 字段采用嵌套命名空间格式**：
+**tags 字段采用 Obsidian 嵌套标签格式**（使用斜杠分隔）：
 
 ```yaml
-tags: ["geo:china", "business:MSSP", "APT", "ransomware"]
+tags: ["geo/china", "business/MSSP", "APT", "ransomware"]
 ```
 
 **支持的命名空间**：
 
 | 前缀 | 说明 | 示例值 |
 |------|------|--------|
-| `geo:` | 地域范围 | `geo:global`, `geo:china`, `geo:china-primary`, `geo:overseas`, `geo:overseas-primary`, `geo:unknown` |
-| `business:` | 业务模式 | `business:MSSP`, `business:SECaaS`, `business:Subscription` 等 |
+| `geo/` | 地域范围 | `geo/global`, `geo/china`, `geo/china-primary`, `geo/overseas`, `geo/overseas-primary`, `geo/unknown` |
+| `business/` | 业务模式 | `business/MSSP`, `business/SECaaS`, `business/Subscription` 等 |
+
+> **Obsidian 规范**：嵌套标签使用斜杠 `/` 分隔，如 `#geo/china`。冒号 `:` 不是有效字符。
 
 **地域范围判断规则（严格模式）**：仅依据文档明确提及的地域信息。
 
@@ -203,48 +205,48 @@ tags: ["geo:china", "business:MSSP", "APT", "ransomware"]
 - 攻击目标地理位置
 - 市场数据覆盖区域
 
-**geo: 值映射**：
+**geo/ 值映射**：
 
 | tag 值 | 判断条件 |
 |--------|----------|
-| `geo:global` | 明确提及"全球"、"国际"、"世界范围"或多国 |
-| `geo:china` | 明确提及"中国"、"国内"，且不涉及海外 |
-| `geo:china-primary` | 主要涉及中国，同时提及海外市场/客户 |
-| `geo:overseas` | 明确提及海外国家/地区，不涉及中国 |
-| `geo:overseas-primary` | 主要涉及海外，同时提及中国市场 |
-| `geo:unknown` | 文档未明确提及地域信息 |
+| `geo/global` | 明确提及"全球"、"国际"、"世界范围"或多国 |
+| `geo/china` | 明确提及"中国"、"国内"，且不涉及海外 |
+| `geo/china-primary` | 主要涉及中国，同时提及海外市场/客户 |
+| `geo/overseas` | 明确提及海外国家/地区，不涉及中国 |
+| `geo/overseas-primary` | 主要涉及海外，同时提及中国市场 |
+| `geo/unknown` | 文档未明确提及地域信息 |
 
-**注意**：无法判断时使用 `geo:unknown`，不要主观推断。
+**注意**：无法判断时使用 `geo/unknown`，不要主观推断。
 
 ### 步骤 4.2：业务模式标签提取（仅 Industry-Analysis）
 
-当 `primary_domain` 或 `secondary_domains` 包含 `Industry-Analysis` 时，提取业务模式标签并添加 `business:` 前缀。
+当 `primary_domain` 或 `secondary_domains` 包含 `Industry-Analysis` 时，提取业务模式标签并添加 `business/` 前缀。
 
-**触发关键词（添加 business: 前缀）**：
+**触发关键词（添加 business/ 前缀）**：
 
 | 标签类别 | 生成 tag 示例 |
 |----------|--------------|
-| 交付模式 | `business:MSSP`, `business:SECaaS`, `business:On-Premise`, `business:Hybrid-Delivery`, `business:Embedded-Security` |
-| 收费模式 | `business:Subscription`, `business:Usage-Based`, `business:Outcome-Based`, `business:Freemium`, `business:License-Based` |
-| 运营模式 | `business:MDR`, `business:MSS`, `business:vCISO`, `business:Security-Operations-Outsourcing`, `business:In-House-Operations` |
-| 合作生态 | `business:Platform-Ecosystem`, `business:Channel-Partner`, `business:OEM-Partnership`, `business:Technology-Alliance`, `business:Co-Development` |
-| 创新模式 | `business:Crowdsourced-Security`, `business:Security-Insurance`, `business:Bug-Bounty-Platform`, `business:Cyber-Risk-Quantification`, `business:Security-Financing`, `business:Data-Sharing-Alliance` |
-| 特殊标签 | `business:New-Business-Model`, `business:Business-Model-Shift` |
+| 交付模式 | `business/MSSP`, `business/SECaaS`, `business/On-Premise`, `business/Hybrid-Delivery`, `business/Embedded-Security` |
+| 收费模式 | `business/Subscription`, `business/Usage-Based`, `business/Outcome-Based`, `business/Freemium`, `business/License-Based` |
+| 运营模式 | `business/MDR`, `business/MSS`, `business/vCISO`, `business/Security-Operations-Outsourcing`, `business/In-House-Operations` |
+| 合作生态 | `business/Platform-Ecosystem`, `business/Channel-Partner`, `business/OEM-Partnership`, `business/Technology-Alliance`, `business/Co-Development` |
+| 创新模式 | `business/Crowdsourced-Security`, `business/Security-Insurance`, `business/Bug-Bounty-Platform`, `business/Cyber-Risk-Quantification`, `business/Security-Financing`, `business/Data-Sharing-Alliance` |
+| 特殊标签 | `business/New-Business-Model`, `business/Business-Model-Shift` |
 
 **提取规则**：
 1. 匹配文档中明确提及的业务模式关键词
-2. 一条情报可打多个 `business:` 标签
-3. 发现新模式时使用 `business:New-Business-Model` 并在内容中描述
-4. 转型场景使用 `business:Business-Model-Shift`
-5. 未提及业务模式时，不添加任何 `business:` 标签
+2. 一条情报可打多个 `business/` 标签
+3. 发现新模式时使用 `business/New-Business-Model` 并在内容中描述
+4. 转型场景使用 `business/Business-Model-Shift`
+5. 未提及业务模式时，不添加任何 `business/` 标签
 
 **tags 生成示例**：
 ```yaml
 # 行业分析情报
-tags: ["geo:china", "business:MSSP", "business:Subscription", "market-growth", "cybersecurity"]
+tags: ["geo/china", "business/MSSP", "business/Subscription", "market-growth", "cybersecurity"]
 
 # 威胁情报
-tags: ["geo:global", "APT", "Lazarus", "financial-sector", "malware"]
+tags: ["geo/global", "APT", "Lazarus", "financial-sector", "malware"]
 ```
 
 ### 步骤 5：生成情报卡片
@@ -303,7 +305,7 @@ created_date: "2026-04-02"
 primary_domain: "Threat-Landscape"
 secondary_domains: ["Vendor-Intelligence"]
 security_relevance: "high"
-tags: ["geo:china-primary", "APT", "Lazarus", "financial-sector", "malware"]
+tags: ["geo/china-primary", "APT", "Lazarus", "financial-sector", "malware"]
 
 # ============================================
 # 第二组：item 来源追溯（继承 + 预处理）
@@ -613,8 +615,8 @@ Bases 是动态查询，每次打开时实时运行：
 - [ ] 每条情报至少满足一个战略标准
 - [ ] 每条情报满足原子化要求（单一主题、独立完整）
 - [ ] 领域分类适当
-- [ ] tags 已填写 — **必填字段**，包含 `geo:` 前缀的地域标签
-- [ ] 业务模式标签已提取并添加 `business:` 前缀（仅 Industry-Analysis）
+- [ ] tags 已填写 — **必填字段**，包含 `geo/` 前缀的地域标签
+- [ ] 业务模式标签已提取并添加 `business/` 前缀（仅 Industry-Analysis）
 - [ ] 情报卡片已按模板生成
 - [ ] 每张卡片有独立的 intelligence_id
 - [ ] 每张卡片有独立的文件名（subject-feature 格式）

--- a/plugins/market-radar/schemas/intelligence-output.schema.json
+++ b/plugins/market-radar/schemas/intelligence-output.schema.json
@@ -202,7 +202,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Nested tags with namespace prefixes (e.g., 'geo:china', 'business:MSSP', 'tech:ai-security')"
+          "description": "Obsidian nested tags with slash separator (e.g., 'geo/china', 'business/MSSP', 'tech/ai-security')"
         },
         "item_id": {
           "type": "string",

--- a/plugins/market-radar/skills/intelligence-output-templates/SKILL.md
+++ b/plugins/market-radar/skills/intelligence-output-templates/SKILL.md
@@ -18,15 +18,17 @@ description: Markdown templates and output structure for intelligence cards. Use
 
 ## tags 嵌套格式
 
-tags 字段使用命名空间前缀：
+tags 字段使用 Obsidian 嵌套标签格式（斜杠分隔）：
 
 ```yaml
-tags: ["geo:china", "business:MSSP", "APT", "ransomware"]
+tags: ["geo/china", "business/MSSP", "APT", "ransomware"]
 ```
 
-- `geo:` 前缀：地域范围（`geo:global`, `geo:china`, `geo:unknown` 等）
-- `business:` 前缀：业务模式（仅 Industry-Analysis）
+- `geo/` 前缀：地域范围（`geo/global`, `geo/china`, `geo/unknown` 等）
+- `business/` 前缀：业务模式（仅 Industry-Analysis）
 - 无前缀：关键词
+
+> **Obsidian 规范**：嵌套标签使用 `/` 分隔，如 `#geo/china`，冒号 `:` 不是有效字符。
 
 ## 写作原则
 

--- a/plugins/market-radar/skills/intelligence-output-templates/references/templates.md
+++ b/plugins/market-radar/skills/intelligence-output-templates/references/templates.md
@@ -16,7 +16,7 @@
 │ primary_domain     - 主领域（七大领域之一）                   │
 │ secondary_domains  - 次领域列表                               │
 │ security_relevance - 安全相关性 high/medium                   │
-│ tags               - 嵌套标签（geo:、business:、关键词）      │
+│ tags               - 嵌套标签（geo/、business/、关键词）      │
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
@@ -57,13 +57,13 @@
 tags 字段使用命名空间前缀组织：
 
 ```yaml
-tags: ["geo:china", "business:MSSP", "APT", "ransomware", "cloud-security"]
+tags: ["geo/china", "business/MSSP", "APT", "ransomware", "cloud-security"]
 ```
 
 | 前缀 | 说明 | 示例值 |
 |------|------|--------|
-| `geo:` | 地域范围 | `geo:global`, `geo:china`, `geo:china-primary`, `geo:overseas`, `geo:unknown` |
-| `business:` | 业务模式 | `business:MSSP`, `business:SECaaS`, `business:Subscription` |
+| `geo/` | 地域范围 | `geo/global`, `geo/china`, `geo/china-primary`, `geo/overseas`, `geo/unknown` |
+| `business/` | 业务模式 | `business/MSSP`, `business/SECaaS`, `business/Subscription` |
 | 无前缀 | 关键词 | `APT`, `ransomware`, `cloud-security`, `zero-trust` |
 
 ---
@@ -80,7 +80,7 @@ created_date: "2026-04-02"
 primary_domain: "Threat-Landscape"
 secondary_domains: []
 security_relevance: "high"
-tags: ["geo:global", "APT", "Lazarus", "financial-sector", "malware"]
+tags: ["geo/global", "APT", "Lazarus", "financial-sector", "malware"]
 
 item_id: "item_a1b2c3d4"
 item_title: "原始标题"
@@ -163,7 +163,7 @@ created_date: "2026-04-02"
 primary_domain: "Industry-Analysis"
 secondary_domains: []
 security_relevance: "medium"
-tags: ["geo:china", "business:MSSP", "business:Subscription", "market-growth", "cybersecurity"]
+tags: ["geo/china", "business/MSSP", "business/Subscription", "market-growth", "cybersecurity"]
 
 item_id: "item_a1b2c3d4"
 item_title: "原始标题"
@@ -250,7 +250,7 @@ created_date: "2026-04-02"
 primary_domain: "Vendor-Intelligence"
 secondary_domains: []
 security_relevance: "medium"
-tags: ["geo:global", "CrowdStrike", "funding", "Series-B", "endpoint-security"]
+tags: ["geo/global", "CrowdStrike", "funding", "Series-B", "endpoint-security"]
 
 item_id: "item_a1b2c3d4"
 item_title: "原始标题"
@@ -334,7 +334,7 @@ created_date: "2026-04-02"
 primary_domain: "Emerging-Tech"
 secondary_domains: []
 security_relevance: "high"
-tags: ["geo:global", "ai-security", "AISP", "LLM-protection", "emerging-tech"]
+tags: ["geo/global", "ai-security", "AISP", "LLM-protection", "emerging-tech"]
 
 item_id: "item_a1b2c3d4"
 item_title: "原始标题"
@@ -420,7 +420,7 @@ created_date: "2026-04-02"
 primary_domain: "Customer-Market"
 secondary_domains: []
 security_relevance: "medium"
-tags: ["geo:china", "enterprise", "security-budget", "procurement", "market-demand"]
+tags: ["geo/china", "enterprise", "security-budget", "procurement", "market-demand"]
 
 item_id: "item_a1b2c3d4"
 item_title: "原始标题"
@@ -503,7 +503,7 @@ created_date: "2026-04-02"
 primary_domain: "Policy-Regulation"
 secondary_domains: []
 security_relevance: "high"
-tags: ["geo:china", "compliance", "data-protection", "regulation", "PIPL"]
+tags: ["geo/china", "compliance", "data-protection", "regulation", "PIPL"]
 
 item_id: "item_a1b2c3d4"
 item_title: "原始标题"
@@ -588,7 +588,7 @@ created_date: "2026-04-02"
 primary_domain: "Capital-Investment"
 secondary_domains: []
 security_relevance: "medium"
-tags: ["geo:global", "funding", "Series-B", "cybersecurity-unicorn", "venture-capital"]
+tags: ["geo/global", "funding", "Series-B", "cybersecurity-unicorn", "venture-capital"]
 
 item_id: "item_a1b2c3d4"
 item_title: "原始标题"
@@ -671,26 +671,26 @@ investors:                     # 投资方/收购方
 tags 字段采用命名空间前缀组织，统一管理地域、业务模式和关键词：
 
 ```yaml
-tags: ["geo:china", "business:MSSP", "business:Subscription", "APT", "ransomware"]
+tags: ["geo/china", "business/MSSP", "business/Subscription", "APT", "ransomware"]
 ```
 
-#### geo: 前缀（地域范围）
+#### geo/ 前缀（地域范围）
 
 | Tag | Description |
 |-----|-------------|
-| `geo:global` | 全球/无特定地域 |
-| `geo:china` | 仅中国 |
-| `geo:china-primary` | 中国为主，涉及海外 |
-| `geo:overseas` | 仅海外 |
-| `geo:overseas-primary` | 海外为主，涉及中国 |
-| `geo:unknown` | 无法判断（默认值） |
+| `geo/global` | 全球/无特定地域 |
+| `geo/china` | 仅中国 |
+| `geo/china-primary` | 中国为主，涉及海外 |
+| `geo/overseas` | 仅海外 |
+| `geo/overseas-primary` | 海外为主，涉及中国 |
+| `geo/unknown` | 无法判断（默认值） |
 
 **判断规则**：
 - 严格模式：仅依据文档明确提及的地域信息
 - 判断依据：明确提及的国家/地区、涉及的公司总部位置、法规适用范围、攻击目标地理位置
-- 无法判断时使用 `geo:unknown`
+- 无法判断时使用 `geo/unknown`
 
-#### business: 前缀（业务模式）
+#### business/ 前缀（业务模式）
 
 **仅适用于 Industry-Analysis 领域**，用于识别网络安全行业的业务模式创新。
 
@@ -698,71 +698,71 @@ tags: ["geo:china", "business:MSSP", "business:Subscription", "APT", "ransomware
 
 | Tag | Description |
 |-----|-------------|
-| `business:MSSP` | 托管安全服务提供商 (Managed Security Service Provider) |
-| `business:SECaaS` | 安全即服务 / 云端交付 (Security as a Service) |
-| `business:On-Premise` | 本地部署模式 |
-| `business:Hybrid-Delivery` | 混合交付（本地+云端） |
-| `business:Embedded-Security` | 内嵌安全（安全能力嵌入其他产品） |
+| `business/MSSP` | 托管安全服务提供商 (Managed Security Service Provider) |
+| `business/SECaaS` | 安全即服务 / 云端交付 (Security as a Service) |
+| `business/On-Premise` | 本地部署模式 |
+| `business/Hybrid-Delivery` | 混合交付（本地+云端） |
+| `business/Embedded-Security` | 内嵌安全（安全能力嵌入其他产品） |
 
 **收费模式类**：
 
 | Tag | Description |
 |-----|-------------|
-| `business:Subscription` | 订阅制（周期性付费） |
-| `business:Usage-Based` | 用量计费 |
-| `business:Outcome-Based` | 结果导向（按效果付费） |
-| `business:Freemium` | 免费增值模式 |
-| `business:License-Based` | 授权制（一次性买断） |
+| `business/Subscription` | 订阅制（周期性付费） |
+| `business/Usage-Based` | 用量计费 |
+| `business/Outcome-Based` | 结果导向（按效果付费） |
+| `business/Freemium` | 免费增值模式 |
+| `business/License-Based` | 授权制（一次性买断） |
 
 **运营模式类**：
 
 | Tag | Description |
 |-----|-------------|
-| `business:MDR` | 托管检测响应服务 (Managed Detection & Response) |
-| `business:MSS` | 托管安全服务 (Managed Security Services) |
-| `business:vCISO` | 虚拟安全官服务 |
-| `business:Security-Operations-Outsourcing` | 安全运营外包 |
-| `business:In-House-Operations` | 自建运营 |
+| `business/MDR` | 托管检测响应服务 (Managed Detection & Response) |
+| `business/MSS` | 托管安全服务 (Managed Security Services) |
+| `business/vCISO` | 虚拟安全官服务 |
+| `business/Security-Operations-Outsourcing` | 安全运营外包 |
+| `business/In-House-Operations` | 自建运营 |
 
 **合作生态类**：
 
 | Tag | Description |
 |-----|-------------|
-| `business:Platform-Ecosystem` | 平台生态（构建开放平台集成 ISV） |
-| `business:Channel-Partner` | 渠道合作（代理商/分销商） |
-| `business:OEM-Partnership` | OEM 合作（技术白牌输出） |
-| `business:Technology-Alliance` | 技术联盟 |
-| `business:Co-Development` | 联合开发 |
+| `business/Platform-Ecosystem` | 平台生态（构建开放平台集成 ISV） |
+| `business/Channel-Partner` | 渠道合作（代理商/分销商） |
+| `business/OEM-Partnership` | OEM 合作（技术白牌输出） |
+| `business/Technology-Alliance` | 技术联盟 |
+| `business/Co-Development` | 联合开发 |
 
 **创新/新兴模式类**：
 
 | Tag | Description |
 |-----|-------------|
-| `business:Crowdsourced-Security` | 众包安全（众包漏洞挖掘/测试） |
-| `business:Security-Insurance` | 安全保险 |
-| `business:Bug-Bounty-Platform` | 漏洞赏金平台 |
-| `business:Cyber-Risk-Quantification` | 网络风险量化服务 |
-| `business:Security-Financing` | 安全金融 |
-| `business:Data-Sharing-Alliance` | 威胁情报共享联盟 |
+| `business/Crowdsourced-Security` | 众包安全（众包漏洞挖掘/测试） |
+| `business/Security-Insurance` | 安全保险 |
+| `business/Bug-Bounty-Platform` | 漏洞赏金平台 |
+| `business/Cyber-Risk-Quantification` | 网络风险量化服务 |
+| `business/Security-Financing` | 安全金融 |
+| `business/Data-Sharing-Alliance` | 威胁情报共享联盟 |
 
 **特殊标签**：
 
 | Tag | Description |
 |-----|-------------|
-| `business:New-Business-Model` | 新出现的业务模式（在 content 中描述） |
-| `business:Business-Model-Shift` | 业务模式转型 |
+| `business/New-Business-Model` | 新出现的业务模式（在 content 中描述） |
+| `business/Business-Model-Shift` | 业务模式转型 |
 
 **使用规则**：
-- 一条情报可打多个 `business:` 标签（如 `business:MSSP` + `business:Subscription`）
-- 发现新模式时使用 `business:New-Business-Model` 并在内容中描述
-- 转型场景使用 `business:Business-Model-Shift`
+- 一条情报可打多个 `business/` 标签（如 `business/MSSP` + `business/Subscription`）
+- 发现新模式时使用 `business/New-Business-Model` 并在内容中描述
+- 转型场景使用 `business/Business-Model-Shift`
 
 #### 无前缀（关键词）
 
 直接使用关键词作为标签，无需命名空间前缀：
 
 ```yaml
-tags: ["geo:global", "APT", "Lazarus", "ransomware", "cloud-security"]
+tags: ["geo/global", "APT", "Lazarus", "ransomware", "cloud-security"]
 ```
 
 **常见关键词类别**：


### PR DESCRIPTION
## Summary

修复 Obsidian 嵌套标签格式，将冒号分隔符改为斜杠。

## Problem

根据 [Obsidian 标签规范](https://obsidian.md/zh/help/tags)：
- 嵌套标签使用 **斜杠 `/`** 分隔：`#收件箱/待阅读`
- 允许的字符：字母、数字、下划线 `_`、连字符 `-`、正斜杠 `/`
- **冒号 `:` 不在允许字符中**

当前实现使用 `geo:china` 格式，Obsidian 无法正确识别为嵌套标签。

## Solution

| 旧格式 | 新格式 |
|--------|--------|
| `geo:china` | `geo/china` |
| `business:MSSP` | `business/MSSP` |
| `geo:china-primary` | `geo/china-primary` |

## Changes

| 文件 | 变更 |
|------|------|
| agents/intelligence-analyzer.md | 更新标签格式和说明 |
| skills/intelligence-output-templates/SKILL.md | 更新标签格式说明 |
| skills/intelligence-output-templates/references/templates.md | 更新所有示例 |
| schemas/intelligence-output.schema.json | 更新描述 |

## Test plan

- [x] 所有 `geo:` 替换为 `geo/`
- [x] 所有 `business:` 替换为 `business/`
- [ ] Obsidian 中验证 `#geo/china` 被识别为嵌套标签

🤖 Generated with [Claude Code](https://claude.com/claude-code)