### PR TITLE
docs: clarify output parameter and output_files path format

### DIFF
--- a/plugins/market-radar/agents/intelligence-analyzer.md
+++ b/plugins/market-radar/agents/intelligence-analyzer.md
@@ -510,6 +510,11 @@ Bases 是动态查询，每次打开时实时运行：
 
 返回轻量 JSON，不包含情报内容详情。
 
+**路径格式约定**：
+- `output_files` 和 `output_file` 字段返回相对于项目根目录的路径
+- 格式为 `{output}/{domain}/{YYYY}/{MM}/{filename}`
+- 例如：`intelligence/Industry-Analysis/2025/10/20251013-cybersecurity-trends-2026.md`
+
 详细格式参见 `references/json-format.md`，Schema 定义参见 `schemas/agent-result.schema.json`。
 
 **四种返回状态**：
@@ -527,22 +532,22 @@ Bases 是动态查询，每次打开时实时运行：
     "emerging-20251013-001"
   ],
   "output_files": [
-    "Industry-Analysis/20251013-cybersecurity-trends-2026.md",
-    "Emerging-Tech/20251013-ai-security-platform-rise.md"
+    "intelligence/Industry-Analysis/2025/10/20251013-cybersecurity-trends-2026.md",
+    "intelligence/Emerging-Tech/2025/10/20251013-ai-security-platform-rise.md"
   ],
   "cards": [
     {
       "intelligence_id": "industry-20251013-001",
       "primary_domain": "Industry-Analysis",
       "secondary_domains": [],
-      "output_file": "Industry-Analysis/20251013-cybersecurity-trends-2026.md",
+      "output_file": "intelligence/Industry-Analysis/2025/10/20251013-cybersecurity-trends-2026.md",
       "title": "Gartner发布2026年网络安全规划指南：六大趋势定义未来方向"
     },
     {
       "intelligence_id": "emerging-20251013-001",
       "primary_domain": "Emerging-Tech",
       "secondary_domains": [],
-      "output_file": "Emerging-Tech/20251013-ai-security-platform-rise.md",
+      "output_file": "intelligence/Emerging-Tech/2025/10/20251013-ai-security-platform-rise.md",
       "title": "AI安全平台（AISP）成为企业安全新焦点"
     }
   ],

--- a/plugins/market-radar/commands/intel-distill.md
+++ b/plugins/market-radar/commands/intel-distill.md
@@ -584,8 +584,10 @@ if (needs_processing + pending_review >= 50) {
 
 **参数**:
 - `source`: 转换文件路径（Agent 从 frontmatter 读取 sourceHash、archivedSource）
-- `output`: 输出目录
+- `output`: 输出目录，值为 `output_dir`（默认 `./intelligence` 或用户指定的 `--output` 参数值）
 - `session_id`: 会话 ID
+
+**写入路径**：Agent 写入情报卡片到 `{output}/{domain}/{YYYY}/{MM}/{filename}`，因此 `output` 参数必须是情报卡片的根目录（如 `./intelligence`），而非项目根目录。
 
 **Agent 职责**：
 - 从 frontmatter 解析元数据（sourceHash、archivedSource）


### PR DESCRIPTION
## 问题背景

执行 `/intel-distill` 命令时，部分情报卡片被错误地写入项目根目录（如 `./Threat-Landscape/...`），而非正确的 `./intelligence/` 目录。

## 根因分析

1. **参数传递不明确**：`intel-distill.md` 中 Agent 调用参数说明不够明确，`output` 参数的值描述为"输出目录"，未明确指出应为 `output_dir` 变量（默认 `./intelligence`）

2. **文档示例不一致**：`intelligence-analyzer.md` 中 `output_files` 示例路径格式为 `Industry-Analysis/xxx.md`，缺少 `intelligence/` 前缀和年月子目录，与实际期望格式不一致

## 修改内容

### intel-distill.md
- 明确 `output` 参数的值为 `output_dir`（默认 `./intelligence` 或用户指定的 `--output` 参数值）
- 添加写入路径说明：`{output}/{domain}/{YYYY}/{MM}/{filename}`

### intelligence-analyzer.md
- 添加"路径格式约定"章节，说明 `output_files` 返回相对于项目根目录的路径
- 修正示例中的路径格式，添加 `intelligence/` 前缀和年月子目录

## 影响范围

仅文档修改，不影响现有功能逻辑。

## 测试

- [ ] 文档格式正确
- [ ] 示例路径格式与实际期望一致